### PR TITLE
syntax (interpolation) changes to support terraform 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ Terraform module to run ECS cluster.
 
 ## Usage
 
-```
+```hcl
 module "example_ecs_cluster" {
-  source              = "github.com/jetbrains-infra/terraform-aws-ecs-cluster"
+  source              = "github.com/jetbrains-infra/terraform-aws-ecs-cluster?ref=vX.X.X" // see https://github.com/jetbrains-infra/terraform-aws-ecs-cluster/releases
   project             = "FooBar"
   cluster_name        = "Example"
-  vpc_id              = "${var.vpc_id}"
+  vpc_id              = var.vpc_id
   
   // subnets with ALB and bastion host e.g..
   trusted_cidr_blocks = [
-    "${aws_subnet.public_subnet_1.cidr_block}",
-    "${aws_subnet.public_subnet_2.cidr_block}"
+    aws_subnet.public_subnet_1.cidr_block,
+    aws_subnet.public_subnet_2.cidr_block
   ]
 }
 ```

--- a/ecs.tf
+++ b/ecs.tf
@@ -1,7 +1,7 @@
 resource "aws_ecs_cluster" "default" {
-  name = "${local.name}"
+  name = local.name
 
-  tags {
-    Project = "${local.project}"
+  tags = {
+    Project = local.project
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -11,22 +11,22 @@ data "aws_iam_policy_document" "ec2_instance_assume_role_policy" {
 }
 
 resource "aws_iam_role" "ec2_instance_role" {
-  assume_role_policy = "${data.aws_iam_policy_document.ec2_instance_assume_role_policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.ec2_instance_assume_role_policy.json
   name               = "EcsCluster${local.name}Ec2InstanceRole"
 
-  tags {
-    Project = "${local.project}"
+  tags = {
+    Project = local.project
   }
 }
 
 resource "aws_iam_role_policy_attachment" "instance_role" {
-  role       = "${aws_iam_role.ec2_instance_role.name}"
+  role       = aws_iam_role.ec2_instance_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
 resource "aws_iam_instance_profile" "ecs_node" {
   name = "EcsCluster${local.name}Ec2InstanceProfile"
-  role = "${aws_iam_role.ec2_instance_role.name}"
+  role = aws_iam_role.ec2_instance_role.name
 }
 
 // Allow ECS service to interact with LoadBalancers
@@ -42,16 +42,16 @@ data "aws_iam_policy_document" "ecs_service_role_policy" {
 }
 
 resource "aws_iam_role" "ecs_service_role" {
-  assume_role_policy = "${data.aws_iam_policy_document.ecs_service_role_policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.ecs_service_role_policy.json
   name               = "EcsCluster${local.name}ServiceRole"
 
-  tags {
-    Project = "${local.project}"
+  tags = {
+    Project = local.project
   }
 }
 
 resource "aws_iam_role_policy_attachment" "service_role" {
-  role       = "${aws_iam_role.ecs_service_role.name}"
+  role       = aws_iam_role.ecs_service_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
 }
 
@@ -68,10 +68,10 @@ data "aws_iam_policy_document" "ecs_task_role_policy" {
 }
 
 resource "aws_iam_role" "ecs_task_role" {
-  assume_role_policy = "${data.aws_iam_policy_document.ecs_task_role_policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_role_policy.json
   name               = "EcsCluster${local.name}DefaultTaskRole"
 
-  tags {
-    Project = "${local.project}"
+  tags = {
+    Project = local.project
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -55,7 +55,6 @@ resource "aws_iam_role_policy_attachment" "service_role" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
 }
 
-//
 data "aws_iam_policy_document" "ecs_task_role_policy" {
   statement {
     actions = ["sts:AssumeRole"]

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,12 +1,12 @@
 resource "aws_security_group" "ecs_nodes" {
   name   = "ECS nodes for ${local.name}"
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
   ingress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["${var.trusted_cidr_blocks}"]
+    cidr_blocks = var.trusted_cidr_blocks
   }
 
   # allow internet access
@@ -17,7 +17,7 @@ resource "aws_security_group" "ecs_nodes" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
-    Project = "${local.project}"
+  tags = {
+    Project = local.project
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,12 +11,12 @@ variable "vpc_id" {
 }
 
 variable "trusted_cidr_blocks" {
-  type    = "list"
+  type    = list(string)
   default = [""]
 }
 
 locals {
-  vpc_id  = "${var.vpc_id}"
-  project = "${var.project}"
-  name    = "${replace(var.cluster_name, " ", "_")}"
+  vpc_id  = var.vpc_id
+  project = var.project
+  name    = replace(var.cluster_name, " ", "_")
 }


### PR DESCRIPTION
Most of the changes are related only to interpolation syntax (or to avoid errors in _tags_ attributes)