### PR TITLE
implement support for lifecycle hooks

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -26,6 +26,20 @@ resource "aws_autoscaling_group" "ecs_nodes" {
     }
   }
 
+  dynamic "initial_lifecycle_hook" {
+    for_each = local.lifecycle_hooks
+    iterator = hook
+    content {
+      name                    = hook.value.name
+      lifecycle_transition    = hook.value.lifecycle_transition
+      default_result          = hook.value.default_result
+      heartbeat_timeout       = hook.value.heartbeat_timeout
+      role_arn                = hook.value.role_arn
+      notification_target_arn = hook.value.notification_target_arn
+      notification_metadata   = hook.value.notification_metadata
+    }
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/variables.tf
+++ b/variables.tf
@@ -53,7 +53,19 @@ variable "on_demand_base_capacity" {
   description = "The minimum number of on-demand EC2 instances"
   default     = 0
 }
-
+variable "lifecycle_hooks" {
+  description = "A list of maps containing the name,lifecycle_transition,default_result,heartbeat_timeout,role_arn,notification_target_arn keys"
+  type = list(object({
+    name                    = string
+    lifecycle_transition    = string
+    default_result          = string
+    heartbeat_timeout       = number
+    role_arn                = string
+    notification_target_arn = string
+    notification_metadata   = string
+  }))
+  default = []
+}
 
 locals {
   vpc_id                  = data.aws_subnet.default.vpc_id
@@ -64,6 +76,7 @@ locals {
   sg_ids                  = distinct(concat(var.security_group_ids, [aws_security_group.ecs_nodes.id]))
   ami_id                  = data.aws_ssm_parameter.ecs_ami.value
   spot                    = var.spot == true ? 0 : 100
+  lifecycle_hooks         = var.lifecycle_hooks
   target_capacity         = var.target_capacity
   protect_from_scale_in   = var.protect_from_scale_in
   user_data               = var.user_data == "" ? [] : [var.user_data]


### PR DESCRIPTION
The only assumption I am unsure sure about in this implementation is that several `initial_lifecycle_hook` blocks within an `aws_autoscaling_group` definition are valid, because this is how I interpret [the terraform documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#initial_lifecycle_hook)

> initial_lifecycle_hook - (Optional) One or more Lifecycle Hooks to attach to the Auto Scaling Group before instances are launched. The syntax is exactly the same as the separate aws_autoscaling_lifecycle_hook resource, without the autoscaling_group_name attribute. Please note that this will only work when creating a new Auto Scaling Group. For all other use-cases, please use aws_autoscaling_lifecycle_hook resource.