### PR TITLE
Ignore changes to aws_autoscaling_group.ecs_nodes desired_capacity

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -42,6 +42,7 @@ resource "aws_autoscaling_group" "ecs_nodes" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [ "desired_capacity" ]
   }
 
   tag {


### PR DESCRIPTION
Right now when the ASG scales we see this in subsequent refreshes

```
  # module.jetbrains_ecs_cluster.aws_autoscaling_group.ecs_nodes has changed
  ~ resource "aws_autoscaling_group" "ecs_nodes" {
      ~ desired_capacity          = 0 -> 2
        id                        = "CLUSTER_NODES_20211227012035340600000002"
        name                      = "CLUSTER_NODES_20211227012035340600000002"
        # (22 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }
```