### PR TITLE
Replace deprecated and archived template provider with cloudinit

### DIFF
--- a/launch_template.tf
+++ b/launch_template.tf
@@ -1,4 +1,4 @@
-data "template_cloudinit_config" "config" {
+data "cloudinit_config" "config" {
   gzip          = false
   base64_encode = true
 
@@ -27,7 +27,7 @@ resource "aws_launch_template" "node" {
   image_id               = local.ami_id
   instance_type          = "t3a.small"
   vpc_security_group_ids = local.sg_ids
-  user_data              = data.template_cloudinit_config.config.rendered
+  user_data              = data.cloudinit_config.config.rendered
   tags                   = local.tags
   update_default_version = true
 


### PR DESCRIPTION
The template provider has been deprecated and archived as per [^1].
Documentation suggests replacing template_cloudinit_config with cloudinit_config.

This is urgent for us because the template provider is not available for darwin/arm64 as discussed in [^2]

[^1]: https://github.com/hashicorp/terraform-provider-template/issues/85
[^2]: https://github.com/hashicorp/terraform-provider-aws/issues/16948