### PR TITLE
Fixed trusted_cidr_blocks variable when empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,7 @@ Type: `list(string)`
 Default:
 
 ```json
-[
-  ""
-]
+[]
 ```
 
 ### <a name="input_user_data"></a> [user\_data](#input\_user\_data)

--- a/security_group.tf
+++ b/security_group.tf
@@ -2,7 +2,7 @@ resource "aws_security_group" "ecs_nodes" {
   name   = "ECS nodes for ${local.name}"
   vpc_id = local.vpc_id
   tags   = local.tags
-  
+
   lifecycle {
     ignore_changes = [
       vpc_id,
@@ -11,6 +11,7 @@ resource "aws_security_group" "ecs_nodes" {
 }
 
 resource "aws_security_group_rule" "ingress" {
+  count             = length(local.trusted_cidr_blocks) != 0 ? 1 : 0
   from_port         = 0
   to_port           = 0
   protocol          = "-1"

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "cluster_name" {
 variable "trusted_cidr_blocks" {
   description = "List of trusted subnets CIDRs with hosts that should connect to the cluster. E.g., subnets with ALB and bastion hosts."
   type        = list(string)
-  default     = [""]
+  default     = []
 }
 
 variable "instance_types" {


### PR DESCRIPTION
# Description

- Error occured when trusted_cidr_blocks is empty

```
╷
│ Error: "" is not a valid CIDR block: invalid CIDR address:
│
│   with module.example_ecs_cluster.aws_security_group_rule.ingress,
│   on .terraform/modules/example_ecs_cluster/security_group.tf line 17, in resource "aws_security_group_rule" "ingress":
│   17:   cidr_blocks       = local.trusted_cidr_blocks
│
╵
```

## sample code
```
module "example_ecs_cluster" {
  source       = "github.com/jetbrains-infra/terraform-aws-ecs-cluster?ref=v0.5.4" // see https://github.com/jetbrains-infra/terraform-aws-ecs-cluster/releases
  cluster_name = "FooBar"

  // subnets where the ECS nodes are hosted
  subnets_ids = [
    aws_subnet.private_subnet_1.id,
    aws_subnet.private_subnet_2.id
  ]
}
```