### PR TITLE
Dynamic network_interfaces to avoid vpc_security_group_ids and network_interfaces in one template

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -4,6 +4,7 @@ resource "aws_autoscaling_group" "ecs_nodes" {
   min_size              = local.asg_min_size
   vpc_zone_identifier   = local.subnets_ids
   protect_from_scale_in = local.protect_from_scale_in
+  desired_capacity_type = "units"
 
   mixed_instances_policy {
     instances_distribution {

--- a/launch_template.tf
+++ b/launch_template.tf
@@ -31,9 +31,12 @@ resource "aws_launch_template" "node" {
   tags                   = local.tags
   update_default_version = true
 
-  network_interfaces {
-    associate_public_ip_address = local.public
-    security_groups             = local.sg_ids
+  dynamic "network_interfaces" {
+    for_each = var.nodes_with_public_ip ? tolist([1]) : tolist([])
+    content {
+      associate_public_ip_address = local.public
+      security_groups             = local.sg_ids
+    }
   }
 
   iam_instance_profile {


### PR DESCRIPTION
Using both network_interfaces and vpc_security_group_ids results in instance creation errors.